### PR TITLE
arduino-cli 0.3.3-alpha

### DIFF
--- a/Formula/arduino-cli.rb
+++ b/Formula/arduino-cli.rb
@@ -1,22 +1,17 @@
 class ArduinoCli < Formula
   desc "Arduino command-line interface"
   homepage "https://github.com/arduino/arduino-cli"
-  url "https://github.com/arduino/arduino-cli/archive/0.3.2-alpha.preview.tar.gz"
-  sha256 "fe0a2766dbe9410e7b9873778c0fe7e693cb82e29db1ce246e9a7eeff2569ed7"
-
-  depends_on "go" => :build
+  url "https://github.com/arduino/arduino-cli/releases/download/0.3.3-alpha.preview/arduino-cli-0.3.3-alpha.preview-osx.zip"
+  version "0.3.3-alpha"
+  sha256 "cc5b2b53fba4b518ab3f3332635645f1149aef6e1a5a9a6e6b91ee2b382f49ad"
 
   def install
-    ENV["GOPATH"] = buildpath
-    (buildpath/"src/github.com/arduino/arduino-cli").install buildpath.children
-
-    cd "src/github.com/arduino/arduino-cli" do
-      system "go", "build", "-o", bin/"arduino-cli"
-      prefix.install_metafiles
-    end
+    mv "./arduino-cli-0.3.3-alpha.preview-osx", "./arduino-cli"
+    bin.install "arduino-cli"
   end
 
   test do
-    system bin/"arduino-cli", "version"
+    assert_equal "arduino-cli version #{version}.preview", shell_output("#{bin}/arduino-cli version").strip
+    system "#{bin}/arduino-cli", "core", "search", "arduino"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Fails audit because the URL contains alpha... Haven't figured out a way to circumvent this, but it may be unavoidable because there is no stable version right now.